### PR TITLE
Missing Column Precondition for Compliance Check - issue fix 467 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <scala.major.version>2.12</scala.major.version>
         <scala.version>${scala.major.version}.10</scala.version>
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
-        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+        <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
 
         <spark.version>3.3.0</spark.version>
     </properties>

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -16,10 +16,11 @@
 
 package com.amazon.deequ.analyzers
 
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions._
 import Analyzers._
+import com.amazon.deequ.analyzers.Preconditions.hasColumn
 import com.google.common.annotations.VisibleForTesting
 
 /**
@@ -34,8 +35,9 @@ import com.google.common.annotations.VisibleForTesting
   *                         describing what the analysis being done for.
   * @param predicate SQL-predicate to apply per row
   * @param where Additional filter to apply before the analyzer is run.
+  * @param columns List of columns used for predicate - This is needed to run pre condition check!
   */
-case class Compliance(instance: String, predicate: String, where: Option[String] = None)
+case class Compliance(instance: String, predicate: String, columns: List[String], where: Option[String] = None)
   extends StandardScanShareableAnalyzer[NumMatchesAndCount]("Compliance", instance)
   with FilterableAnalyzer {
 
@@ -59,4 +61,7 @@ case class Compliance(instance: String, predicate: String, where: Option[String]
   private def criterion: Column = {
     conditionalSelection(expr(predicate), where).cast(IntegerType)
   }
+
+  override protected def additionalPreconditions(): Seq[StructType => Unit] =
+    columns.map(hasColumn)
 }

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -306,12 +306,13 @@ object Constraint {
   def complianceConstraint(
       name: String,
       column: String,
+      columns: List[String],
       assertion: Double => Boolean,
       where: Option[String] = None,
       hint: Option[String] = None)
     : Constraint = {
 
-    val compliance = Compliance(name, column, where)
+    val compliance = Compliance(name, column, columns, where)
 
     val constraint = AnalysisBasedConstraint[NumMatchesAndCount, Double, Double](
       compliance, assertion, hint = hint)

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -242,6 +242,7 @@ private[deequ] object AnalyzerSerializer
         result.addProperty(WHERE_FIELD, compliance.where.orNull)
         result.addProperty("instance", compliance.instance)
         result.addProperty("predicate", compliance.predicate)
+        result.add(COLUMNS_FIELD, context.serialize(compliance.columns.asJava))
 
       case patternMatch: PatternMatch =>
         result.addProperty(ANALYZER_NAME_FIELD, "PatternMatch")
@@ -384,6 +385,7 @@ private[deequ] object AnalyzerDeserializer
         Compliance(
           json.get("instance").getAsString,
           json.get("predicate").getAsString,
+          getColumnsAsSeq(context, json).toList,
           getOptionalWhereParam(json))
 
       case "PatternMatch" =>

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
@@ -66,7 +66,7 @@ case class CategoricalRangeRule(
 
     val description = s"'${profile.column}' has value range $categoriesSql"
     val columnCondition = s"`${profile.column}` IN ($categoriesSql)"
-    val constraint = complianceConstraint(description, columnCondition, Check.IsOne)
+    val constraint = complianceConstraint(description, columnCondition, List(profile.column), Check.IsOne)
 
     ConstraintSuggestion(
       constraint,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
@@ -86,7 +86,7 @@ case class FractionalCategoricalRangeRule(
       s"${targetCompliance * 100}% of values"
     val columnCondition = s"`${profile.column}` IN ($categoriesSql)"
     val hint = s"It should be above $targetCompliance!"
-    val constraint = complianceConstraint(description, columnCondition, _ >= targetCompliance,
+    val constraint = complianceConstraint(description, columnCondition, List(profile.column), _ >= targetCompliance,
       hint = Some(hint))
 
     ConstraintSuggestion(

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/NonNegativeNumbersRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/NonNegativeNumbersRule.scala
@@ -34,7 +34,7 @@ case class NonNegativeNumbersRule() extends ConstraintRule[ColumnProfile] {
   override def candidate(profile: ColumnProfile, numRecords: Long): ConstraintSuggestion = {
 
     val description = s"'${profile.column}' has no negative values"
-    val constraint = complianceConstraint(description, s"${profile.column} >= 0", Check.IsOne)
+    val constraint = complianceConstraint(description, s"${profile.column} >= 0", List(profile.column), Check.IsOne)
 
     val minimum = profile match {
       case numericProfile: NumericColumnProfile

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -242,7 +242,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val min = new Check(CheckLevel.Error, "rule7").hasMin("val1", _ > 1)
       val max = new Check(CheckLevel.Error, "rule8").hasMax("val1", _ <= 3)
       val compliance = new Check(CheckLevel.Error, "rule9")
-        .satisfies("item < 1000", "rule9")
+        .satisfies("item < 1000", "rule9", List("item"))
       val expectedColumn1 = isComplete.description
       val expectedColumn2 = completeness.description
       val expectedColumn3 = minLength.description
@@ -308,7 +308,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val patternMatchNullString = new Check(CheckLevel.Error, "rule3")
         .hasPattern("att2", """\w""".r)
       val complianceNullValue = new Check(CheckLevel.Error, "rule4")
-        .satisfies("val2 > 3", "rule4")
+        .satisfies("val2 > 3", "rule4", List("val2"))
 
       val expectedColumn1 = min.description
       val expectedColumn2 = max.description
@@ -758,7 +758,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val expectedConstraints = Seq(
         Constraint.completenessConstraint("att1", _ == 1.0),
-        Constraint.complianceConstraint("att1 is positive", "att1", _ == 1.0)
+        Constraint.complianceConstraint("att1 is positive", "att1", List("att1"), _ == 1.0)
       )
 
       val check = expectedConstraints.foldLeft(Check(CheckLevel.Error, "check")) {

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -200,7 +200,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
   "Compliance analyzer" should {
     "compute correct metrics " in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      val result1 = Compliance("rule1", "att1 > 3").calculate(df)
+      val result1 = Compliance("rule1", "att1 > 3", List("att1")).calculate(df)
       inside(result1) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
         entity shouldBe Entity.Column
         name shouldBe "Compliance"
@@ -209,7 +209,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
         fullColumn.isDefined shouldBe true
       }
 
-      val result2 = Compliance("rule2", "att1 > 2").calculate(df)
+      val result2 = Compliance("rule2", "att1 > 2", List("att1")).calculate(df)
       inside(result2) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
         entity shouldBe Entity.Column
         name shouldBe "Compliance"
@@ -221,7 +221,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "compute correct metrics with filtering" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      val result = Compliance("rule1", "att2 = 0", Some("att1 < 4")).calculate(df)
+      val result = Compliance("rule1", "att2 = 0", List("att1"), Some("att1 < 4")).calculate(df)
       inside(result) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
         entity shouldBe Entity.Column
         name shouldBe "Compliance"
@@ -233,7 +233,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "fail on wrong column input" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      Compliance("rule1", "attNoSuchColumn > 3").calculate(df) match {
+      Compliance("rule1", "attNoSuchColumn > 3", List("attNoSuchColumn")).calculate(df) match {
         case metric =>
           assert(metric.entity == Entity.Column)
           assert(metric.name == "Compliance")

--- a/src/test/scala/com/amazon/deequ/analyzers/ComplianceTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/ComplianceTest.scala
@@ -31,7 +31,7 @@ class ComplianceTest extends AnyWordSpec with Matchers with SparkContextSpec wit
 
       val data = getDfWithNumericValues(session)
 
-      val att1Compliance = Compliance("rule1", "att1 > 3")
+      val att1Compliance = Compliance("rule1", "att1 > 3", List("att1"))
       val state = att1Compliance.computeStateFrom(data)
       val metric: DoubleMetric with FullColumn = att1Compliance.computeMetricFrom(state)
 
@@ -42,7 +42,7 @@ class ComplianceTest extends AnyWordSpec with Matchers with SparkContextSpec wit
 
       val data = getDfWithNumericValues(session)
 
-      val att1Compliance = Compliance("rule1", "attNull > 3")
+      val att1Compliance = Compliance("rule1", "attNull > 3", List("att1"))
       val state = att1Compliance.computeStateFrom(data)
       val metric: DoubleMetric with FullColumn = att1Compliance.computeMetricFrom(state)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
@@ -67,9 +67,9 @@ class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContex
         val initialStates = InMemoryStateProvider()
 
         val analyzers = Seq(
-          Compliance("attributeNonNull", "attribute IS NOT NULL"),
-          Compliance("categoryAttribute", "attribute LIKE 'CATEGORY%'"),
-          Compliance("attributeKeyword", "attribute LIKE '%keyword%'"),
+          Compliance("attributeNonNull", "attribute IS NOT NULL", List("attribute")),
+          Compliance("categoryAttribute", "attribute LIKE 'CATEGORY%'", List("attribute")),
+          Compliance("attributeKeyword", "attribute LIKE '%keyword%'", List("attribute")),
           Completeness("marketplace_id"),
           Completeness("item"))
 

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
@@ -55,7 +55,7 @@ class IncrementalAnalyzerTest extends AnyWordSpec with Matchers with SparkContex
   "ComplianceAnalyzer" should {
     "compute correct metrics" in withSparkSession { session =>
 
-      val analyzer = Compliance("att1", "att1 = 'b'")
+      val analyzer = Compliance("att1", "att1 = 'b'", List("att1"))
 
       val initial = initialData(session)
       val delta = deltaData(session)

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
@@ -38,7 +38,7 @@ class StateAggregationTests extends AnyWordSpec with Matchers with SparkContextS
       correctlyAggregatesStates(session, CountDistinct("value" :: Nil))
       correctlyAggregatesStates(session, UniqueValueRatio("attribute" :: "value" :: Nil))
       correctlyAggregatesStates(session, Completeness("attribute"))
-      correctlyAggregatesStates(session, Compliance("attribute", "attribute like '%facets%'"))
+      correctlyAggregatesStates(session, Compliance("attribute", "attribute like '%facets%'", List("attribute")))
       correctlyAggregatesStates(session, ApproxCountDistinct("attribute"))
       correctlyAggregatesStates(session, MutualInformation("numbersA", "numbersB"))
       correctlyAggregatesStates(session, Correlation("numbersA", "numbersB"))

--- a/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
@@ -41,7 +41,7 @@ class StateProviderTest extends AnyWordSpec
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
         Completeness("att1"), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        Compliance("att1", "att1 = 'b'"), data)
+        Compliance("att1", "att1 = 'b'", List("att1")), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
         PatternMatch("att1", Patterns.EMAIL), data)
 
@@ -80,7 +80,7 @@ class StateProviderTest extends AnyWordSpec
       assertCorrectlyRestoresNumMatchesAndCount(provider, provider,
         Completeness("att1"), data)
       assertCorrectlyRestoresNumMatchesAndCount(provider, provider,
-        Compliance("att1", "att1 = 'b'"), data)
+        Compliance("att1", "att1 = 'b'", List("att1")), data)
 
       assertCorrectlyRestoresNumMatchesAndCount(provider, provider,
         PatternMatch("att1", Patterns.EMAIL), data)

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -16,8 +16,9 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.{SparkContextSpec, VerificationSuite}
 import com.amazon.deequ.analyzers._
+import com.amazon.deequ.checks.{Check, CheckLevel, CheckStatus}
 import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.repository.ResultKey
@@ -64,9 +65,9 @@ class AnalysisRunnerTests extends AnyWordSpec
         val df = getDfWithNumericValues(sparkSession)
 
         val analyzers =
-          Completeness("att1") :: Compliance("rule1", "att1 > 3") ::
-          Completeness("att2") :: Compliance("rule1", "att1 > 2") ::
-          Compliance("rule1", "att2 > 2") ::
+          Completeness("att1") :: Compliance("rule1", "att1 > 3", List("att1")) ::
+          Completeness("att2") :: Compliance("rule1", "att1 > 2", List("att1")) ::
+          Compliance("rule1", "att2 > 2", List("att1")) ::
           ApproxQuantile("att2", 0.5) :: Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
@@ -385,5 +386,60 @@ class AnalysisRunnerTests extends AnyWordSpec
           .run()
       }
     }
-  }
+
+    "A well-defined check should pass even if an ill-defined check is also configured" in withSparkSession {
+      sparkSession =>
+      val df = getDfWithNameAndAge(sparkSession)
+
+        val checkThatShouldSucceed =
+          Check(CheckLevel.Error, "shouldSucceedForValue").isComplete("name")
+
+        val complianceCheckThatShouldSucceed =
+          Check(CheckLevel.Error, "shouldSucceedForAge").isContainedIn("age", 1, 100)
+
+        val complianceCheckThatShouldFailForAge =
+          Check(CheckLevel.Error, "shouldFailForAge").isContainedIn("age", 1, 19)
+
+        val checkThatShouldFail = Check(CheckLevel.Error, "shouldErrorColumnNA")
+          .isContainedIn("fakeColumn", 10, 90)
+
+        val complianceCheckThatShouldFail = Check(CheckLevel.Error, "shouldErrorStringType")
+          .isContainedIn("name", 1, 3)
+
+        val complianceCheckThatShouldFailCompleteness = Check(CheckLevel.Error, "shouldErrorStringType")
+          .hasCompleteness("fake", x => x > 0)
+
+        val verificationResult = VerificationSuite()
+          .onData(df)
+          .addCheck(checkThatShouldSucceed)
+          .addCheck(complianceCheckThatShouldSucceed)
+          .addCheck(complianceCheckThatShouldFailForAge)
+          .addCheck(checkThatShouldFail)
+          .addCheck(complianceCheckThatShouldFail)
+          .addCheck(complianceCheckThatShouldFailCompleteness)
+          .run()
+
+        val checkSuccessResult = verificationResult.checkResults(checkThatShouldSucceed)
+        checkSuccessResult.constraintResults.map(_.message) shouldBe List(None)
+        assert(checkSuccessResult.status == CheckStatus.Success)
+
+        val checkAgeSuccessResult = verificationResult.checkResults(complianceCheckThatShouldSucceed)
+        checkAgeSuccessResult.constraintResults.map(_.message) shouldBe List(None)
+        assert(checkAgeSuccessResult.status == CheckStatus.Success)
+
+        val checkFailedResult = verificationResult.checkResults(checkThatShouldFail)
+        checkFailedResult.constraintResults.map(_.message) shouldBe List(Some("Input data does not include column fakeColumn!"))
+        assert(checkFailedResult.status == CheckStatus.Error)
+
+        val checkFailedResultStringType = verificationResult.checkResults(complianceCheckThatShouldFail)
+        checkFailedResultStringType.constraintResults.map(_.message) shouldBe
+          List(Some("Empty state for analyzer Compliance(name between 1.0 and 3.0,`name` IS NULL OR (`name` >= 1.0 AND `name` <= 3.0),List(name),None), all input values were NULL."))
+        assert(checkFailedResultStringType.status == CheckStatus.Error)
+
+        val checkFailedCompletenessResult = verificationResult.checkResults(complianceCheckThatShouldFailCompleteness)
+        checkFailedCompletenessResult.constraintResults.map(_.message) shouldBe List(Some("Input data does not include column fake!"))
+        assert(checkFailedCompletenessResult.status == CheckStatus.Error)
+
+      }
+    }
 }

--- a/src/test/scala/com/amazon/deequ/checks/ApplicabilityTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/ApplicabilityTest.scala
@@ -157,7 +157,7 @@ class ApplicabilityTest extends AnyWordSpec with SparkContextSpec {
 
       val applicability = new Applicability(session)
 
-      val analyzerWithInvalidExpression1 = Compliance("", "")
+      val analyzerWithInvalidExpression1 = Compliance("", "", List.empty)
 
       val resultForAnalyzerWithInvalidExpression1 =
         applicability.isApplicable(Seq(analyzerWithInvalidExpression1), schema)

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -298,13 +298,13 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
     "return the correct check status for columns constraints" in withSparkSession { sparkSession =>
 
       val check1 = Check(CheckLevel.Error, "group-1")
-        .satisfies("att1 > 0", "rule1")
+        .satisfies("att1 > 0", "rule1", List("att1"))
 
       val check2 = Check(CheckLevel.Error, "group-2-to-fail")
-        .satisfies("att1 > 3", "rule2")
+        .satisfies("att1 > 3", "rule2", List("att1"))
 
       val check3 = Check(CheckLevel.Error, "group-2-to-succeed")
-        .satisfies("att1 > 3", "rule3", _ == 0.5)
+        .satisfies("att1 > 3", "rule3", List("att1"), _ == 0.5)
 
       val context = runChecks(getDfWithNumericValues(sparkSession), check1, check2, check3)
 
@@ -317,13 +317,13 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       withSparkSession { sparkSession =>
 
         val checkToSucceed = Check(CheckLevel.Error, "group-1")
-          .satisfies("att1 < att2", "rule1").where("att1 > 3")
+          .satisfies("att1 < att2", "rule1", List("att1")).where("att1 > 3")
 
         val checkToFail = Check(CheckLevel.Error, "group-1")
-          .satisfies("att2 > 0", "rule2").where("att1 > 0")
+          .satisfies("att2 > 0", "rule2", List("att1")).where("att1 > 0")
 
         val checkPartiallyGetsSatisfied = Check(CheckLevel.Error, "group-1")
-          .satisfies("att2 > 0", "rule3", _ == 0.5).where("att1 > 0")
+          .satisfies("att2 > 0", "rule3", List("att1"), _ == 0.5).where("att1 > 0")
 
         val context = runChecks(getDfWithNumericValues(sparkSession), checkToSucceed, checkToFail,
           checkPartiallyGetsSatisfied)

--- a/src/test/scala/com/amazon/deequ/checks/FilterableCheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/FilterableCheckTest.scala
@@ -35,8 +35,8 @@ class FilterableCheckTest extends AnyWordSpec
         .isComplete("col1")
         .isComplete("col2").where("marketplace = 'EU'")
         .hasCompleteness("col3", _ >= 0.9).where("marketplace = 'NA'")
-        .satisfies("someCol > 5", "const1")
-        .satisfies("someCol > 10", "const2").where("marketplace = 'EU'")
+        .satisfies("someCol > 5", "const1", List("someCol"))
+        .satisfies("someCol > 10", "const2", List("someCol")).where("marketplace = 'EU'")
 
       val completenessAnalyzers =
         check.requiredAnalyzers()

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -37,7 +37,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
       Completeness("ColumnA") ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Compliance("rule1", "att1 > 3") ->
+      Compliance("rule1", "att1 > 3", List("att1")) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
       ApproxCountDistinct("columnA", Some("test")) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -391,4 +391,12 @@ trait FixtureSupport {
       ("6", "a", "f")
     ).toDF("item.one", "att.1", "att.2")
   }
+
+  def getDfWithNameAndAge(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+    Seq(
+      ("foo", 50),
+      ("bar", 20)
+    ).toDF("name", "age")
+  }
 }


### PR DESCRIPTION
Issue fix #467

*Description of changes:*

Added the `additionalPreconditions` for Compliance constraint so the compliance check would fail and not spark operation. Used the columns check for the condition to fail instead of letting it skip the precondition. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
